### PR TITLE
add new way to check attributes to avoid dynamic limitations

### DIFF
--- a/src/Example/Program.cs
+++ b/src/Example/Program.cs
@@ -18,7 +18,7 @@ namespace Example
             File.WriteAllText(@"Output/Notification.html", GenerateNotification());
             File.WriteAllText(@"Output/Blocks.html", GenerateBlocks());
             File.WriteAllText(@"Output/Withfooter.html", GenerateWithfooter());
-            File.WriteAllText(@"Output/CustomThemeAndRawHtml.html", GenerateCustomThemeAndRawHtml()); 
+            File.WriteAllText(@"Output/CustomThemeAndRawHtml.html", GenerateCustomThemeAndRawHtml());
             File.WriteAllText(@"Output/AnotherWay.html", GenerateAnotherWay());
             File.WriteAllText(@"Output/OverrideDefaultTemplate.html", GenerateOverrideDefaultTemplate());
             File.WriteAllText(@"Output/WithImage.html", GenerateWithImages());
@@ -62,23 +62,23 @@ namespace Example
             template
                 .Paragraph(m =>
                     "<p style='" +
-                    (m.IsProperty(() => m.Attributes.color) ? $"color:{m.Attributes.color};" : string.Empty) +
-                    (m.IsProperty(() => m.Attributes.backgroundColor) ? $"background-color:{m.Attributes.backgroundColor};" : string.Empty) +
+                    (m.HasAttribute("color") ? $"color:{m.Attributes.color};" : string.Empty) +
+                    (m.HasAttribute("backgroundColor") ? $"background-color:{m.Attributes.backgroundColor};" : string.Empty) +
                     $"'>{m.Content}</p>")
                 .Body(m => "<html><body>" + m.Content + "<br />" + m.Footer + "</body></html>")
                 .Text(m =>
                     $"<span style='" +
-                    (m.IsProperty(() => m.Attributes.color) ? $"color:{m.Attributes.color};" : string.Empty) +
-                    (m.IsProperty(() => m.Attributes.backgroundColor) ? $"background-color:{m.Attributes.backgroundColor};" : string.Empty) +
-                    (m.IsProperty(() => m.Attributes.fontWeight) ? $"font-weight:{m.Attributes.fontWeight};" : string.Empty) +
+                    (m.HasAttribute("color") ? $"color:{m.Attributes.color};" : string.Empty) +
+                    (m.HasAttribute("backgroundColor") ? $"background-color:{m.Attributes.backgroundColor};" : string.Empty) +
+                    (m.HasAttribute("fontWeight") ? $"font-weight:{m.Attributes.fontWeight};" : string.Empty) +
                     $"'>{m.Content}</span>");
 
             var footer = MailBody
                 .CreateBlock()
-                .Text("Follow ", new { color = "red"})
+                .Text("Follow ", new { color = "red" })
                 .Link("http://twitter.com/example", "@Example")
                 .Text(" on Twitter.", new { color = "#009900", backgroundColor = "#CCCCCC", fontWeight = "bold" });
-            
+
             var body = MailBody
                 .CreateBody(template, footer)
                 .Paragraph("Please confirm your email address by clicking the link below.")
@@ -86,7 +86,7 @@ namespace Example
                 .Button("https://www.example.com/", "Confirm Email Address")
                 .Paragraph("— [Insert company name here]", new { color = "white", backgroundColor = "black" })
                 .ToString();
-            
+
             return body;
         }
 
@@ -96,7 +96,7 @@ namespace Example
 
             // Format product display.
             var items = products.Select(item => MailBody.CreateBlock().Text(item));
-            
+
             var body = MailBody
                 .CreateBody()
                 .Title("Confirmation of your order")
@@ -117,10 +117,10 @@ namespace Example
             var productStatus = "available";
             var productDescription = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sagittis nisl ut tellus egestas facilisis. Nulla eget erat dictum, facilisis libero sit amet, sollicitudin tortor. Morbi iaculis, urna eu tincidunt dapibus, sapien ex dictum nibh, non congue urna tellus vitae risus.";
             var components = new string[] { "Part A", "Part B" };
-            
+
             // Format product display.
             var items = components.Select(item => MailBody.CreateBlock().Text(item));
-            
+
             var body = MailBody
                 .CreateBody()
                 .Paragraph("Hello,")
@@ -138,15 +138,15 @@ namespace Example
 
             return body;
         }
-		
-		public static string GenerateBlocks()
+
+        public static string GenerateBlocks()
         {
             var componentsArray = new string[] { "Block A", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sagittis nisl ut tellus egestas facilisis. Nulla eget erat dictum, facilisis libero sit amet, sollicitudin tortor. Morbi iaculis, urna eu tincidunt dapibus, sapien ex dictum nibh, non congue urna tellus vitae risus." };
-            var buttonsArray = new Tuple<string,string>[] { Tuple.Create<string,string>("http://www.google.com", "Button A"), Tuple.Create<string, string>("http://www.disney.com", "Button B") };
-            
+            var buttonsArray = new Tuple<string, string>[] { Tuple.Create<string, string>("http://www.google.com", "Button A"), Tuple.Create<string, string>("http://www.disney.com", "Button B") };
+
             var items = componentsArray.Select(item => MailBody.CreateBlock().Paragraph(item));
             var buttons = buttonsArray.Select(item => MailBody.CreateBlock().Button(item.Item1, item.Item2));
-            
+
             var body = MailBody
                 .CreateBody()
                 .Paragraph("Hello,")
@@ -651,7 +651,7 @@ namespace Example
                 .Button("https://example.com/", "Confirm Email Address")
                 .Paragraph("— [Insert company name here]")
                 .ToString();
-            
+
             return body;
         }
 
@@ -667,6 +667,20 @@ namespace Example
                 .ToString();
 
             return body;
+        }
+
+        public static MailBodyTemplate GetOnlyParagraphWithFontSizeStyleTemplate()
+        {
+            var template = MailBodyTemplate.GetDefaultTemplate()
+                .Paragraph(m =>
+                {
+                    string fontSize = null;
+                    var hasFontSize = m.TryGetAttribute<string>("fontSize", out fontSize);
+                    return $"<p{(hasFontSize ? $" style='font-size: {fontSize};'" : "")}>{m.Content}</p>";
+                })
+                .Body(m => m.Content);
+
+            return template;
         }
     }
 }

--- a/src/MailBody/MailBody.csproj
+++ b/src/MailBody/MailBody.csproj
@@ -35,4 +35,12 @@
     <Reference Include="System.Dynamic.Runtime" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+    <DefineConstants>NETSTANDARD14</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>NETSTANDARD16</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/src/MailBody/MailElements/ContentElement.cs
+++ b/src/MailBody/MailElements/ContentElement.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CSharp.RuntimeBinder;
+﻿using System.Reflection;
+using System;
+using System.Collections;
 
 namespace MailBodyPack
 {
@@ -7,25 +9,67 @@ namespace MailBodyPack
         public string Content { get; set; }
         public dynamic Attributes { get; set; }
 
-        public delegate string GetValueDelegate();
-        public bool IsProperty(GetValueDelegate getValueMethod)
+        public bool TryGetAttribute<T>(string attr, out T val)
         {
+            val = default(T);
             try
             {
-                //we're not interesting in the return value.
-                //What we need to know is whether an exception occurred or not
+                if (Attributes == null || string.IsNullOrEmpty(attr))
+                {
+                    return false;
+                }
 
-                var v = getValueMethod();
-                return (v == null) ? false : true;
-            }
-            catch (RuntimeBinderException)
-            {
+                Type type = (Attributes as object).GetType();
+
+                PropertyInfo property = null;
+
+#if NETSTANDARD14
+                property = type.GetTypeInfo().GetDeclaredProperty(attr);
+#elif NETSTANDARD16
+                property = type.GetTypeInfo().GetProperty(attr);
+#else
+                property = type.GetProperty(attr);
+#endif
+
+                if (property != null)
+                {
+                    val = (T)property.GetValue(Attributes, null);
+                    return true;
+                }
+
+                bool isDict = false;
+
+#if NETSTANDARD14
+                isDict = typeof(IDictionary).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo());
+#elif NETSTANDARD16
+                isDict = typeof(IDictionary).GetTypeInfo().IsAssignableFrom(type);
+#else
+                isDict = typeof(IDictionary).IsAssignableFrom(type);
+#endif
+
+                if (isDict)
+                {
+                    IDictionary dictionary = (IDictionary)Attributes;
+                    
+                    if (dictionary.Contains(attr))
+                    {
+                        val = (T)dictionary[attr];
+                        return true;
+                    }
+                }
+
                 return false;
             }
             catch
             {
-                return true;
+                return false;
             }
+        }
+
+        public bool HasAttribute(string attr)
+        {
+            object T = null;
+            return TryGetAttribute(attr, out T) && T != null;
         }
     }
 }

--- a/src/Tests/MailBodyTest.cs
+++ b/src/Tests/MailBodyTest.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Xunit;
 using MailBodyPack;
-using System.IO;
 
 namespace Tests
 {
@@ -56,7 +52,7 @@ namespace Tests
                 .Text("Follow ")
                 .Link("http://twitter.com/example", "@Example")
                 .Text(" on Twitter.");
-            
+
             var body = MailBody
                 .CreateBody(template, footer)
                 .Paragraph("Please confirm your email address by clicking the link below.")
@@ -72,6 +68,132 @@ namespace Tests
         public void RunExampleProject()
         {
             Example.Program.Main(new string[0]);
+        }
+
+        public class CssAttributes
+        {
+            public string FontSize { get; set; }
+        }
+
+        [Fact]
+        public void ElementHasAttributeFromAnonymousObject()
+        {
+            var element = new ContentElement
+            {
+                Content = "<p>test</p>",
+                Attributes = new { fontSize = "12px" }
+            };
+
+            Assert.True(element.HasAttribute("fontSize"));
+            Assert.False(element.HasAttribute("color"));
+        }
+
+        [Fact]
+        public void ElementHasAttributeFromDictionary()
+        {
+            var element = new ContentElement
+            {
+                Content = "<p>test</p>",
+                Attributes = new Dictionary<string, string>() { ["fontSize"] = "12px" }
+            };
+
+            Assert.True(element.HasAttribute("fontSize"));
+            Assert.False(element.HasAttribute("color"));
+        }
+
+        [Fact]
+        public void ElementHasAttributeFromClass()
+        {
+            var element = new ContentElement
+            {
+                Content = "<p>test</p>",
+                Attributes = new CssAttributes { FontSize = "12px" }
+            };
+
+            Assert.True(element.HasAttribute("FontSize"));
+            Assert.False(element.HasAttribute("color"));
+        }
+
+        [Fact]
+        public void ElementTryGetAttributeFromAnonymousObject()
+        {
+            var element = new ContentElement
+            {
+                Content = "<p>test</p>",
+                Attributes = new { fontSize = "12px" }
+            };
+
+            string size = null;
+            bool sizeExist = element.TryGetAttribute("fontSize", out size);
+
+            Assert.True(sizeExist);
+            Assert.Equal("12px", size);
+
+            string color = null;
+            bool colorExist = element.TryGetAttribute("color", out size);
+
+            Assert.False(colorExist);
+            Assert.Null(color);
+        }
+
+        [Fact]
+        public void ElementTryGetAttributeFromDictionary()
+        {
+            var element = new ContentElement
+            {
+                Content = "<p>test</p>",
+                Attributes = new Dictionary<string, string>() { ["fontSize"] = "12px" }
+            };
+
+            string size = null;
+            bool sizeExist = element.TryGetAttribute("fontSize", out size);
+
+            Assert.True(sizeExist);
+            Assert.Equal("12px", size);
+
+            string color = null;
+            bool colorExist = element.TryGetAttribute("color", out size);
+
+            Assert.False(colorExist);
+            Assert.Null(color);
+        }
+
+        [Fact]
+        public void ElementTryGetAttributeFromClass()
+        {
+            var element = new ContentElement
+            {
+                Content = "<p>test</p>",
+                Attributes = new CssAttributes { FontSize = "12px" }
+            };
+
+            string size = null;
+            bool sizeExist = element.TryGetAttribute("FontSize", out size);
+
+            Assert.True(sizeExist);
+            Assert.Equal("12px", size);
+
+            string color = null;
+            bool colorExist = element.TryGetAttribute("color", out size);
+
+            Assert.False(colorExist);
+            Assert.Null(color);
+        }
+
+        [Fact]
+        public void DifferentAssemblyDynamicAttributesTest()
+        {
+            string text = "test";
+            string size = "12px";
+
+            var template = Example.Program.GetOnlyParagraphWithFontSizeStyleTemplate();
+
+            var html = MailBody
+                .CreateBody(template)
+                .Paragraph(text, new { fontSize = size })
+                .GenerateHtml();
+
+            Assert.Equal($"<p style='font-size: {size};'>{text}</p>", html);
         }
     }
 }


### PR DESCRIPTION
- remove `bool IsProperty(GetValueDelegate getValueMethod)`
- remove `delegate string GetValueDelegate`
- add `bool TryGetAttribute<T>(string attr, out T val)`
- add `bool HasAttribute(string attr)`
- improve tests

resolves #7 

--
@doxakis It took me a long time to set up a dev environment because of the outdated `.net` targets, but I eventually managed to run it.

I had to use some workarounds because some `Reflection` methods varied for `.net4x`, `.netstandard1.4` and `.netstandard1.6`. I believe I finally solved it.

I was unable to make the test project work, so I created a new one with the existing test cases and some additional ones. All tests passed, so I copied the new test cases to the current `Tests` project. I can push the new project as well if you want.

![image](https://user-images.githubusercontent.com/13673443/228811417-82b31f80-b5ea-4e1c-8b0e-64b5860d769f.png)

I replaced the `IsProperty` method with `TryGetAttribute` and `HasAttribute`. These new methods can handle anonymous objects, regular objects and dictionaries.